### PR TITLE
Handle line endings across operating systems

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior for handling line endings between operating systems, in case people don't have core.autocrlf set.  See https://help.github.com/articles/dealing-with-line-endings/
+* text=auto


### PR DESCRIPTION
Since each team member could be using a different operating system it is a good idea to set up Git's method of normalising all text file line endings to `LF`. This is a way that doesn't require team members to change their local settings.

See: https://help.github.com/articles/dealing-with-line-endings/