### PR TITLE
Add Open Sans and Lato webfonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Atomist Clone</title>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  <link href="https://fonts.googleapis.com/css?family=Lato|Open+Sans" rel="stylesheet">
   <link rel="stylesheet" type="text/css" href="styles/main.css">
 </head>
 <body>


### PR DESCRIPTION
The Atomist page uses Open Sans and Brandon Grotesque. The first is a free font available from Google, the second is proprietary. Several online sources suggest that Lato is a close Google webfont match for capital letters (which is all we need). They can be used with the following CSS rules:

`font-family: 'Lato', sans-serif;`
`font-family: 'Open Sans', sans-serif;`

Closes #2 