### PR TITLE
Fix features container desktop width

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -117,8 +117,14 @@ pre, code {
 }
 
 #features #row {
-    width: 95%;
+    max-width: 1170px;
     margin: 0 auto;
+}
+
+@media (max-width: 1200px) {
+    #features #row {
+	max-width: 95%;
+    }
 }
 
 #features img#create {


### PR DESCRIPTION
This adds a breakpoint at 1200px viewport width so that the container of the three features columns has a maximum width of 1170px above this width (95% below).