### PR TITLE
Remove unneeded margins from CTA button

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -317,7 +317,6 @@ h1+span {
   color: white;
   font-family: "Lato", sans-serif;
   letter-spacing: 1.75px;
-  margin: 30px auto 200px;
 }
 /* Slice 3 - Features: END */
 


### PR DESCRIPTION
These margins don't seem to be needed any more. They prevent the CTA section contents from being vertically aligned.